### PR TITLE
Fixed ScanPage navigation Bug

### DIFF
--- a/BFH_USZ_PICC/BFH_USZ_PICC/Services/NavigationService.cs
+++ b/BFH_USZ_PICC/BFH_USZ_PICC/Services/NavigationService.cs
@@ -92,7 +92,7 @@ namespace BFH_USZ_PICC.Services
                 nav = Application.Current.MainPage.Navigation;
             }
 
-            if(modal)
+            if(!modal)
             {
                 await nav?.PushAsync(pushingPage);
             } else

--- a/BFH_USZ_PICC/BFH_USZ_PICC/Services/NavigationService_iOS.cs
+++ b/BFH_USZ_PICC/BFH_USZ_PICC/Services/NavigationService_iOS.cs
@@ -31,7 +31,7 @@ namespace BFH_USZ_PICC.Services
                 nav = Application.Current.MainPage.Navigation;
             }
 
-            if (modal)
+            if (!modal)
             {
                 await nav?.PushAsync(pushingPage);
             }


### PR DESCRIPTION
## Fixes
- Fixing Bug gausing to display the scan page in a modal style. This caused iOS users to be unable to abort the scan.